### PR TITLE
No longer require XCom pickling for 2.2.5

### DIFF
--- a/src/astro_databricks/operators/notebook.py
+++ b/src/astro_databricks/operators/notebook.py
@@ -12,11 +12,11 @@ from databricks_cli.runs.api import RunsApi
 from databricks_cli.sdk.api_client import ApiClient
 
 from astro_databricks.constants import JOBS_API_VERSION
+from astro_databricks.operators.workflow import DatabricksMetaData
 from astro_databricks.plugins.plugin import (
     DatabricksJobRepairSingleFailedLink,
     DatabricksJobRunLink,
 )
-from astro_databricks.operators.workflow import DatabricksMetaData
 
 
 class DatabricksNotebookOperator(BaseOperator):
@@ -93,7 +93,7 @@ class DatabricksNotebookOperator(BaseOperator):
         self.notebook_params = notebook_params or {}
         self.notebook_packages = notebook_packages or []
         self.databricks_conn_id = databricks_conn_id
-        self.databricks_metadata: DatabricksMetaData | None = None
+        self.databricks_metadata: dict | None = None
         self.job_cluster_key = job_cluster_key or ""
         self.new_cluster = new_cluster or {}
         self.existing_cluster_id = existing_cluster_id or ""
@@ -248,6 +248,8 @@ class DatabricksNotebookOperator(BaseOperator):
         ):
             self.launch_notebook_job()
         else:
-            self.databricks_run_id = self.databricks_metadata.databricks_run_id
-            self.databricks_conn_id = self.databricks_metadata.databricks_conn_id
+            # if we are in a workflow, we assume there is a metadata from the launch task
+            databricks_metadata = DatabricksMetaData(**self.databricks_metadata)
+            self.databricks_run_id = databricks_metadata.databricks_run_id
+            self.databricks_conn_id = databricks_metadata.databricks_conn_id
         self.monitor_databricks_job()

--- a/src/astro_databricks/operators/workflow.py
+++ b/src/astro_databricks/operators/workflow.py
@@ -171,11 +171,11 @@ class _CreateDatabricksWorkflowOperator(BaseOperator):
             print("job pending")
             time.sleep(5)
         self.databricks_run_id = run_id
-        return DatabricksMetaData(
-            databricks_conn_id=self.databricks_conn_id,
-            databricks_run_id=run_id,
-            databricks_job_id=job_id,
-        )
+        return {
+            "databricks_conn_id": self.databricks_conn_id,
+            "databricks_job_id": job_id,
+            "databricks_run_id": run_id,
+        }
 
 
 class DatabricksWorkflowTaskGroup(TaskGroup):

--- a/src/astro_databricks/plugins/plugin.py
+++ b/src/astro_databricks/plugins/plugin.py
@@ -238,7 +238,12 @@ def get_task_group(operator):
         task_group = operator.task_group
     return task_group
 
-def get_xcom_result(ti_key: TaskInstanceKey, key: str, ti: TaskInstance | None, ) -> Any:
+
+def get_xcom_result(
+    ti_key: TaskInstanceKey,
+    key: str,
+    ti: TaskInstance | None,
+) -> Any:
     # Pull the xcom result for the given task instance and task instance key
     try:
         result = XCom.get_value(
@@ -248,14 +253,18 @@ def get_xcom_result(ti_key: TaskInstanceKey, key: str, ti: TaskInstance | None, 
     except AttributeError:
         # For Airflow versions < 2.3.0 which do not contain the XCOM.get_value method implementation.
         if not ti:
-            raise TaskInstanceNotFound("Valid task instance is needed to fetch the XCOM result.")
+            raise TaskInstanceNotFound(
+                "Valid task instance is needed to fetch the XCOM result."
+            )
         result = XCom.get_one(
             task_id=ti_key.task_id,
             dag_id=ti_key.dag_id,
             execution_date=ti.execution_date,
             key=key,
         )
-    return result
+    from astro_databricks.operators.workflow import DatabricksMetaData
+
+    return DatabricksMetaData(**result)
 
 
 class DatabricksJobRunLink(BaseOperatorLink, LoggingMixin):

--- a/tests/databricks/test_notebook.py
+++ b/tests/databricks/test_notebook.py
@@ -5,7 +5,6 @@ import pytest
 from airflow.exceptions import AirflowException
 from astro_databricks.operators.notebook import DatabricksNotebookOperator
 from astro_databricks.operators.workflow import (
-    DatabricksMetaData,
     DatabricksWorkflowTaskGroup,
 )
 
@@ -73,11 +72,11 @@ def test_databricks_notebook_operator_without_taskgroup(mock_monitor, mock_launc
 def test_databricks_notebook_operator_with_taskgroup(
     mock_create, mock_monitor, mock_launch, dag
 ):
-    mock_create.return_value = DatabricksMetaData(
-        databricks_job_id="job_id",
-        databricks_conn_id="conn_id",
-        databricks_run_id="run_id",
-    )
+    mock_create.return_value = {
+        "databricks_job_id": "job_id",
+        "databricks_run_id": "run_id",
+        "databricks_conn_id": "conn_id",
+    }
     with dag:
         task_group = DatabricksWorkflowTaskGroup(
             group_id="test_workflow",


### PR DESCRIPTION
In the current implementation, we pass a "DatabricksMetadata" object via Xcom that contains basic metadata like run id and conn id. When supporting earlier versions of Airflow, this would mean that users have to turn on xcom pickling (which would be a security risk). To avoid this risk we simply return a json dictionary that we can then manually deserialize as needed.